### PR TITLE
Add server-side infection simulation per player

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const path = require('path');
 const fs = require('fs');
+const SimulationManager = require('./simulation/simulationManager');
+const { countries } = require('./simulation/playerSimulation');
 
 const app = express();
 
@@ -43,12 +45,25 @@ app.use(express.static('public'));
 let wasmModule = null;
 const Module = require('./main.js');
 let runSimulation = null;
+const simulationManager = new SimulationManager();
 
 async function loadWasm() {
     const wasmModule = await Module(); // zavoláš funkciu, nedávaj len require()
 
     runSimulation = wasmModule.cwrap('runSimulation', 'string', ['string']);
     console.log("✅ WASM loaded and bound.");
+}
+
+function serializeCountries() {
+    return Object.entries(countries).map(([name, data]) => ({
+        name,
+        code: data.code,
+        region: data.region,
+        neighbors: data.neighbors,
+        security: data.security,
+        connectivity: data.connectivity,
+        population: data.population
+    }));
 }
 app.post('/simulate', (req, res) => {
     try {
@@ -104,8 +119,7 @@ app.get('/creator/:filename', (req, res) => {
     const filename = req.params.filename;
     const filePath = path.join(__dirname, 'creator', `${filename}.json`);
 
-    if (!
-    fs.existsSync(filePath)) {
+    if (!fs.existsSync(filePath)) {
         return res.status(404).json({ error: "File not found" });
     }
     try {
@@ -117,7 +131,68 @@ app.get('/creator/:filename', (req, res) => {
     }
 });
 
+app.get('/api/countries', (req, res) => {
+    res.json(serializeCountries());
+});
+
+app.get('/api/players', (req, res) => {
+    const summaries = simulationManager.getPlayerSummaries();
+    res.json(summaries);
+});
+
+app.post('/api/players/:playerId', (req, res) => {
+    const { playerId } = req.params;
+    try {
+        const session = simulationManager.upsertPlayer(playerId, req.body || {});
+        session.tick(Date.now());
+        res.json(session.getSnapshot());
+    } catch (err) {
+        console.error("❌ Failed to create or update player:", err);
+        res.status(400).json({ error: err.message });
+    }
+});
+
+app.get('/api/players/:playerId', (req, res) => {
+    const { playerId } = req.params;
+    const session = simulationManager.getPlayer(playerId);
+    if (!session) {
+        return res.status(404).json({ error: "Player not found" });
+    }
+    session.tick(Date.now());
+    res.json(session.getSnapshot());
+});
+
+app.post('/api/players/:playerId/infections', (req, res) => {
+    const { playerId } = req.params;
+    const { country, reapply } = req.body || {};
+
+    if (!country) {
+        return res.status(400).json({ error: "Country is required" });
+    }
+
+    const session = simulationManager.getPlayer(playerId);
+    if (!session) {
+        return res.status(404).json({ error: "Player not found" });
+    }
+
+    try {
+        const result = session.startInfection(country, { reapply, source: 'player' });
+        session.tick(Date.now());
+        res.json({ infection: result, state: session.getSnapshot() });
+    } catch (err) {
+        console.error("❌ Failed to start infection:", err);
+        res.status(400).json({ error: err.message });
+    }
+});
+
+app.delete('/api/players/:playerId', (req, res) => {
+    const { playerId } = req.params;
+    const removed = simulationManager.removePlayer(playerId);
+    res.json({ removed });
+});
+
 app.listen(port, async () => {
     await loadWasm();
+    simulationManager.start();
     console.log(`🚀 Server running on http://localhost:${port}`);
 });

--- a/simulation/countryGraph.js
+++ b/simulation/countryGraph.js
@@ -1,0 +1,138 @@
+module.exports = {
+  "United States": {
+    code: "US",
+    region: "North America",
+    neighbors: ["Canada", "Mexico", "United Kingdom", "Brazil"],
+    security: 0.85,
+    connectivity: 0.9,
+    population: 0.9
+  },
+  "Canada": {
+    code: "CA",
+    region: "North America",
+    neighbors: ["United States", "United Kingdom"],
+    security: 0.8,
+    connectivity: 0.7,
+    population: 0.3
+  },
+  "Mexico": {
+    code: "MX",
+    region: "North America",
+    neighbors: ["United States", "Brazil", "Spain"],
+    security: 0.55,
+    connectivity: 0.6,
+    population: 0.6
+  },
+  "Brazil": {
+    code: "BR",
+    region: "South America",
+    neighbors: ["Mexico", "United States", "Spain", "South Africa"],
+    security: 0.5,
+    connectivity: 0.7,
+    population: 0.8
+  },
+  "United Kingdom": {
+    code: "GB",
+    region: "Europe",
+    neighbors: ["United States", "Canada", "Germany", "France", "India"],
+    security: 0.82,
+    connectivity: 0.85,
+    population: 0.4
+  },
+  "Germany": {
+    code: "DE",
+    region: "Europe",
+    neighbors: ["United Kingdom", "France", "Russia"],
+    security: 0.88,
+    connectivity: 0.8,
+    population: 0.5
+  },
+  "France": {
+    code: "FR",
+    region: "Europe",
+    neighbors: ["United Kingdom", "Germany", "Spain", "Egypt"],
+    security: 0.78,
+    connectivity: 0.75,
+    population: 0.5
+  },
+  "Spain": {
+    code: "ES",
+    region: "Europe",
+    neighbors: ["France", "Mexico", "Brazil", "Nigeria"],
+    security: 0.7,
+    connectivity: 0.7,
+    population: 0.45
+  },
+  "Russia": {
+    code: "RU",
+    region: "Europe",
+    neighbors: ["Germany", "China", "India"],
+    security: 0.8,
+    connectivity: 0.65,
+    population: 0.7
+  },
+  "China": {
+    code: "CN",
+    region: "Asia",
+    neighbors: ["Russia", "India", "Japan", "Australia"],
+    security: 0.75,
+    connectivity: 0.9,
+    population: 1
+  },
+  "India": {
+    code: "IN",
+    region: "Asia",
+    neighbors: ["United Kingdom", "Russia", "China", "Saudi Arabia"],
+    security: 0.6,
+    connectivity: 0.8,
+    population: 1
+  },
+  "Japan": {
+    code: "JP",
+    region: "Asia",
+    neighbors: ["China", "Australia"],
+    security: 0.83,
+    connectivity: 0.85,
+    population: 0.45
+  },
+  "Australia": {
+    code: "AU",
+    region: "Oceania",
+    neighbors: ["China", "Japan", "India"],
+    security: 0.76,
+    connectivity: 0.7,
+    population: 0.25
+  },
+  "South Africa": {
+    code: "ZA",
+    region: "Africa",
+    neighbors: ["Brazil", "Nigeria", "Egypt", "Saudi Arabia"],
+    security: 0.55,
+    connectivity: 0.6,
+    population: 0.35
+  },
+  "Nigeria": {
+    code: "NG",
+    region: "Africa",
+    neighbors: ["Spain", "South Africa", "Egypt"],
+    security: 0.45,
+    connectivity: 0.55,
+    population: 0.7
+  },
+  "Egypt": {
+    code: "EG",
+    region: "Africa",
+    neighbors: ["France", "Nigeria", "Saudi Arabia", "South Africa"],
+    security: 0.58,
+    connectivity: 0.6,
+    population: 0.5
+  },
+  "Saudi Arabia": {
+    code: "SA",
+    region: "Asia",
+    neighbors: ["India", "Egypt", "South Africa"],
+    security: 0.65,
+    connectivity: 0.65,
+    population: 0.4
+  }
+};

--- a/simulation/playerSimulation.js
+++ b/simulation/playerSimulation.js
@@ -1,0 +1,330 @@
+const countries = require('./countryGraph');
+
+const DEFAULT_ATTRIBUTES = Object.freeze({
+  spread: 0.5,
+  stealth: 0.5,
+  resilience: 0.5
+});
+
+const canonicalNameMap = new Map();
+for (const [name, data] of Object.entries(countries)) {
+  canonicalNameMap.set(name.toLowerCase(), name);
+  if (data.code) {
+    canonicalNameMap.set(data.code.toLowerCase(), name);
+  }
+}
+
+function clamp(value, min = 0, max = 1) {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.min(Math.max(value, min), max);
+}
+
+function clamp01(value) {
+  return clamp(value, 0, 1);
+}
+
+function parseNumber(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function sanitizeAttributes(attrs = {}) {
+  const withDefaults = { ...DEFAULT_ATTRIBUTES, ...attrs };
+  return {
+    spread: clamp01(parseNumber(withDefaults.spread, DEFAULT_ATTRIBUTES.spread)),
+    stealth: clamp01(parseNumber(withDefaults.stealth, DEFAULT_ATTRIBUTES.stealth)),
+    resilience: clamp01(parseNumber(withDefaults.resilience, DEFAULT_ATTRIBUTES.resilience))
+  };
+}
+
+function resolveCountryName(input) {
+  if (!input) {
+    return null;
+  }
+  const normalized = String(input).trim().toLowerCase();
+  return canonicalNameMap.get(normalized) || null;
+}
+
+function getCanonicalCountryName(name) {
+  if (!name) {
+    return null;
+  }
+  if (countries[name]) {
+    return name;
+  }
+  return resolveCountryName(name);
+}
+
+class PlayerSimulation {
+  constructor(playerId, options = {}) {
+    if (!playerId) {
+      throw new Error('playerId is required to create a simulation session.');
+    }
+
+    this.playerId = String(playerId);
+    this.infections = new Map();
+    this.exposure = new Map();
+    this.events = [];
+    this.lastTick = Date.now();
+    this.totalInfected = 0;
+    this.maxEventLog = 60;
+
+    this.malwareQuality = 0.5;
+    this.attributes = { ...DEFAULT_ATTRIBUTES };
+
+    this.updateConfig(options, { silent: true });
+  }
+
+  updateConfig(config = {}, { silent = false } = {}) {
+    if (config.malwareQuality !== undefined) {
+      const parsedQuality = parseNumber(config.malwareQuality, this.malwareQuality);
+      this.malwareQuality = clamp01(parsedQuality);
+    } else if (this.malwareQuality === undefined) {
+      this.malwareQuality = 0.5;
+    }
+
+    const mergedAttributes = { ...this.attributes, ...(config.attributes || {}) };
+    this.attributes = sanitizeAttributes(mergedAttributes);
+
+    if (!silent) {
+      this.recordEvent('CONFIG_UPDATED', {
+        malwareQuality: this.malwareQuality,
+        attributes: { ...this.attributes }
+      });
+    }
+
+    return {
+      malwareQuality: this.malwareQuality,
+      attributes: { ...this.attributes }
+    };
+  }
+
+  recordEvent(type, payload = {}) {
+    const event = {
+      type,
+      timestamp: Date.now(),
+      ...payload
+    };
+    this.events.push(event);
+    if (this.events.length > this.maxEventLog) {
+      this.events.shift();
+    }
+    return event;
+  }
+
+  computeBasePower() {
+    const quality = this.malwareQuality ?? 0.5;
+    const spread = this.attributes?.spread ?? 0.5;
+    const resilience = this.attributes?.resilience ?? 0.5;
+
+    const weighted = 0.5 * quality + 0.35 * spread + 0.15 * resilience;
+    return clamp01(0.02 + 0.18 * weighted);
+  }
+
+  computeSpreadRate(sourceName, targetName, basePower = this.computeBasePower()) {
+    const source = countries[sourceName];
+    const target = countries[targetName];
+    if (!source || !target) {
+      return 0;
+    }
+
+    const connectivity = (source.connectivity + target.connectivity) / 2;
+    const populationPressure = 0.5 + (target.population || 0) * 0.5;
+    const securityMitigation = 1 - (target.security || 0);
+    if (securityMitigation <= 0) {
+      return 0;
+    }
+
+    const resilienceBoost = 0.8 + (this.attributes.resilience || 0) * 0.4;
+
+    const rate = basePower * connectivity * populationPressure * securityMitigation * resilienceBoost;
+    return Math.max(0, rate);
+  }
+
+  startInfection(countryName, options = {}) {
+    const resolved = getCanonicalCountryName(countryName);
+    if (!resolved) {
+      throw new Error(`Unknown country: ${countryName}`);
+    }
+
+    const now = Date.now();
+    const existing = this.infections.get(resolved);
+    if (existing) {
+      if (options.reapply) {
+        existing.intensity = clamp01((existing.intensity || this.computeBasePower()) + this.computeBasePower() * 0.25);
+        existing.lastBoostedAt = now;
+        this.recordEvent('INTENSIFIED', {
+          country: resolved,
+          intensity: existing.intensity
+        });
+      }
+      return { alreadyInfected: true, country: resolved };
+    }
+
+    const intensity = clamp01(options.intensity !== undefined
+      ? parseNumber(options.intensity, 0.5)
+      : 0.4 + 0.6 * (0.5 * this.malwareQuality + 0.5 * this.attributes.spread));
+
+    this.infections.set(resolved, {
+      infectedAt: now,
+      intensity
+    });
+    this.totalInfected += 1;
+    this.exposure.delete(resolved);
+
+    this.recordEvent('INFECTED', {
+      country: resolved,
+      source: options.source || 'direct',
+      intensity
+    });
+
+    return { country: resolved, intensity };
+  }
+
+  tick(now = Date.now()) {
+    const currentTime = Number(now);
+    if (!Number.isFinite(currentTime)) {
+      return;
+    }
+
+    const deltaSeconds = (currentTime - this.lastTick) / 1000;
+    if (!Number.isFinite(deltaSeconds) || deltaSeconds <= 0) {
+      this.lastTick = currentTime;
+      return;
+    }
+
+    // Natural decay of pending exposures based on security and malware stealth/resilience
+    for (const [countryName, progress] of [...this.exposure.entries()]) {
+      const country = countries[countryName];
+      if (!country) {
+        this.exposure.delete(countryName);
+        continue;
+      }
+
+      const baseDecay = (0.01 + (country.security || 0) * 0.05) * deltaSeconds;
+      const stealthMitigation = 1 + (this.attributes.stealth || 0) * 0.8;
+      const resilienceMitigation = 1 + (this.attributes.resilience || 0) * 0.4;
+      const adjustedDecay = baseDecay / (stealthMitigation * resilienceMitigation);
+      const newProgress = progress - adjustedDecay;
+      if (newProgress <= 0.0001) {
+        this.exposure.delete(countryName);
+      } else {
+        this.exposure.set(countryName, newProgress);
+      }
+    }
+
+    if (this.infections.size === 0) {
+      this.lastTick = currentTime;
+      return;
+    }
+
+    const basePower = this.computeBasePower();
+
+    for (const [sourceName, infection] of [...this.infections.entries()]) {
+      const source = countries[sourceName];
+      if (!source) {
+        continue;
+      }
+
+      infection.intensity = clamp01((infection.intensity || basePower) + basePower * deltaSeconds * 0.1);
+
+      for (const neighborRaw of source.neighbors) {
+        const neighborName = getCanonicalCountryName(neighborRaw);
+        if (!neighborName || this.infections.has(neighborName)) {
+          continue;
+        }
+
+        const spreadRate = this.computeSpreadRate(sourceName, neighborName, basePower);
+        if (spreadRate <= 0) {
+          continue;
+        }
+
+        const current = this.exposure.get(neighborName) || 0;
+        const next = current + spreadRate * deltaSeconds;
+        if (next >= 1) {
+          const intensity = clamp01(basePower + spreadRate);
+          this.infections.set(neighborName, {
+            infectedAt: currentTime,
+            intensity
+          });
+          this.exposure.delete(neighborName);
+          this.totalInfected += 1;
+          this.recordEvent('INFECTED', {
+            country: neighborName,
+            source: sourceName,
+            via: 'neighbor',
+            intensity
+          });
+        } else {
+          this.exposure.set(neighborName, Math.min(next, 0.999));
+        }
+      }
+    }
+
+    this.lastTick = currentTime;
+  }
+
+  getCountryMetrics(name) {
+    const data = countries[name];
+    if (!data) {
+      return null;
+    }
+    return {
+      code: data.code,
+      region: data.region,
+      security: data.security,
+      connectivity: data.connectivity,
+      population: data.population
+    };
+  }
+
+  getSnapshot() {
+    const infectedCountries = Array.from(this.infections.entries())
+      .map(([country, details]) => ({
+        country,
+        infectedAt: details.infectedAt,
+        intensity: Number(((details.intensity ?? 0)).toFixed(3)),
+        metrics: this.getCountryMetrics(country)
+      }))
+      .sort((a, b) => a.infectedAt - b.infectedAt);
+
+    const pendingExposures = Array.from(this.exposure.entries())
+      .map(([country, progress]) => ({
+        country,
+        progress: Number(Math.min(progress, 1).toFixed(3)),
+        metrics: this.getCountryMetrics(country)
+      }))
+      .sort((a, b) => b.progress - a.progress);
+
+    return {
+      playerId: this.playerId,
+      malwareQuality: this.malwareQuality,
+      attributes: { ...this.attributes },
+      totalInfected: this.totalInfected,
+      activeInfections: this.infections.size,
+      infectedCountries,
+      pendingExposures,
+      events: this.events.slice(-25),
+      lastTick: this.lastTick
+    };
+  }
+
+  getSummary() {
+    return {
+      playerId: this.playerId,
+      malwareQuality: this.malwareQuality,
+      activeInfections: this.infections.size,
+      pendingTargets: this.exposure.size,
+      totalInfected: this.totalInfected,
+      lastTick: this.lastTick
+    };
+  }
+}
+
+module.exports = {
+  PlayerSimulation,
+  countries,
+  resolveCountryName
+};

--- a/simulation/simulationManager.js
+++ b/simulation/simulationManager.js
@@ -1,0 +1,77 @@
+const { PlayerSimulation } = require('./playerSimulation');
+
+class SimulationManager {
+  constructor({ tickMs = 1000 } = {}) {
+    this.sessions = new Map();
+    this.tickMs = tickMs;
+    this.interval = null;
+  }
+
+  start() {
+    if (this.interval) {
+      return;
+    }
+    this.interval = setInterval(() => {
+      this.tickAll(Date.now());
+    }, this.tickMs);
+
+    if (this.interval.unref) {
+      this.interval.unref();
+    }
+  }
+
+  stop() {
+    if (!this.interval) {
+      return;
+    }
+    clearInterval(this.interval);
+    this.interval = null;
+  }
+
+  ensureTicker() {
+    if (!this.interval) {
+      this.start();
+    }
+  }
+
+  getPlayer(playerId) {
+    return this.sessions.get(String(playerId));
+  }
+
+  upsertPlayer(playerId, config = {}) {
+    const id = String(playerId);
+    let session = this.sessions.get(id);
+    if (!session) {
+      session = new PlayerSimulation(id, config);
+      this.sessions.set(id, session);
+    } else {
+      session.updateConfig(config);
+    }
+    this.ensureTicker();
+    return session;
+  }
+
+  removePlayer(playerId) {
+    const removed = this.sessions.delete(String(playerId));
+    if (this.sessions.size === 0) {
+      this.stop();
+    }
+    return removed;
+  }
+
+  listPlayers() {
+    return Array.from(this.sessions.keys());
+  }
+
+  getPlayerSummaries() {
+    return Array.from(this.sessions.values()).map((session) => session.getSummary());
+  }
+
+  tickAll(now = Date.now()) {
+    for (const session of this.sessions.values()) {
+      session.tick(now);
+    }
+  }
+}
+
+module.exports = SimulationManager;


### PR DESCRIPTION
## Summary
- add a country graph with security/connectivity metadata for infection calculations
- implement a PlayerSimulation model and SimulationManager to tick infections for each player on the server
- expose REST endpoints so clients can configure players, trigger infections, and inspect live simulation state

## Testing
- node --check server.js
- node --check simulation/playerSimulation.js
- node --check simulation/simulationManager.js

------
https://chatgpt.com/codex/tasks/task_e_68ca7cda40c88328a681a63d539fbd4c